### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Additional releases are available here: https://updates.jenkins-ci.org/download/
 All plugin releases are also available on the [Synopsys public artifactory](https://sig-repo.synopsys.com/webapp/#/artifacts/browse/tree/General/bds-integrations-release/org/jenkins-ci/plugins/synopsys-polaris)
 
 # Documentation
-The documentation is located [here](https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/475922472/Polaris+Software+Integrity+Platform+for+Jenkins+Integration).
+The documentation is located [here](https://community.synopsys.com/s/document-item?bundleId=polaris_ci_integrations&topicId=topics%2Fc_polaris-overview.html&_LANG=enus).
  


### PR DESCRIPTION
Direct documentation to the current link.
This will avoid the redirection occurring in Confluence.